### PR TITLE
Add remaining heroes that include hyphens in battle.net URL

### DIFF
--- a/heroes-sidebar-master/freeRotation.py
+++ b/heroes-sidebar-master/freeRotation.py
@@ -46,8 +46,11 @@ class freeRotation:
 			'Varian':'',
 		}
 		subs = {
+                        'liming': 'li-ming',
 			'ltmorales': 'lt-morales',
+                        'sgthammer': 'sgt-hammer',
 			'thebutcher': 'the-butcher',
+                        'thelostvikings': 'the-lost-vikings',
 		}
 
 		self.freeRotation.append("")


### PR DESCRIPTION
I got these last ones by hovering over the links on this page:
http://us.battle.net/heroes/en/heroes/#/