### PR TITLE
bin: add link_flair.py for interacting with link flair on submissions

### DIFF
--- a/bin/link_flair.py
+++ b/bin/link_flair.py
@@ -1,0 +1,23 @@
+import argparse
+import praw
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Get or set link flair')
+    parser.add_argument('action', choices=['get', 'set'], help='get or set')
+    parser.add_argument('id', help='id of the submission')
+    parser.add_argument('--text', help='link flair text to set')
+    parser.add_argument('--class', help='link flair CSS class to set')
+    args = vars(parser.parse_args())
+
+    reddit = praw.Reddit('moderation')
+    submission = reddit.submission(args['id'])
+
+    if args['action'] == 'get':
+        print('Flair text: {0}'.format(submission.link_flair_text))
+        print('Flair class: {0}'.format(submission.link_flair_css_class))
+    elif args['action'] == 'set':
+        submission.mod.flair(args['text'], args['class'])
+        print('Link flair set')
+
+main()


### PR DESCRIPTION
To get currently assigned link flair:
```
$ python link_flair.py get 5ok5r9
Flair text: Blue Post
Flair class: bluepost
```

To set link flair:
```
$ python link_flair.py set 5ok5r9 --text "Blue Post" --class "bluepost"
Link flair set
```

I made this because Reddit doesn't include a way to set arbitrary link flair on posts outside of the defined templates, which are made available to all users when we allow users to set link flair. This way, mods can set arbitrary link flair themselves.