### PR TITLE
automation: strip - characters from hero names for css id

### DIFF
--- a/automation/hero.py
+++ b/automation/hero.py
@@ -7,7 +7,7 @@ class Hero:
     well as convert to different representations (battle.net slug,
     CSS class)."""
 
-    PUNCTUATION_BLACKLIST = (",", ".", "`", "'")
+    PUNCTUATION_BLACKLIST = (",", ".", "`", "'", "-")
 
     def __init__(self, name):
         if name not in HEROES:


### PR DESCRIPTION
I missed the dash character from the punctuation blacklist, which
appears in hero names like Li-Ming.